### PR TITLE
Return proper exit code.

### DIFF
--- a/lib/protest.rb
+++ b/lib/protest.rb
@@ -97,5 +97,9 @@ Protest.report_with((ENV["PROTEST_REPORT"] || "documentation").to_sym)
 Protest.backtrace_filter = Protest::Utils::BacktraceFilter.new
 
 at_exit do
-  Protest.run_all_tests! if Protest.autorun?
+  if Protest.autorun?
+    Protest.run_all_tests!
+    report = Protest.instance_variable_get(:@report)
+    exit report.failures_and_errors.empty?
+  end
 end


### PR DESCRIPTION
Return exit code 1 when there are failure or error tests.

This fixes the problem with Travis and other CI who takes the `exit code` to define if tests run ok.
