### PR TITLE
Don't change error code if exit has been called

### DIFF
--- a/lib/protest.rb
+++ b/lib/protest.rb
@@ -97,6 +97,8 @@ Protest.report_with((ENV["PROTEST_REPORT"] || "documentation").to_sym)
 Protest.backtrace_filter = Protest::Utils::BacktraceFilter.new
 
 at_exit do
+  exit $!.status if $!.is_a?(SystemExit) && !$!.success?
+
   if Protest.autorun?
     Protest.run_all_tests!
     report = Protest.instance_variable_get(:@report)


### PR DESCRIPTION
The `at_exit` block is setting a status code considering only if tests have passed.

There are cases on which a test, or a helper, would call exit with an error code, in those cases, this is the error code that should be reported.
