### PR TITLE
Feature: Optional Fail Early

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,13 +249,13 @@ documentation for details, or take a look at the source code for
 If needed, you can configure Protest to stop the execution when the first error
 or failed assertion occurs.
 
-This can be configured with the `fail_fast` method:
+This can be configured with the `fail_early` method:
 
 ```ruby
-Protest.fail_fast = true
+Protest.fail_early = true
 ```
 
-This feature can be configured by passing a `PROTEST_FAIL_FAST` environment
+This feature can be configured by passing a `PROTEST_FAIL_EARLY` environment
 variable, to activate it you must set it to `"true"`.
 
 ## Using Rails?

--- a/README.md
+++ b/README.md
@@ -244,6 +244,20 @@ register your subclass by calling `Protest.add_report`. See the
 documentation for details, or take a look at the source code for
 `Protest::Reports::Progress` and `Protest::Reports::Documentation`.
 
+## Failing Early
+
+If needed, you can configure Protest to stop the execution when the first error
+or failed assertion occurs.
+
+This can be configured with the `fail_fast` method:
+
+```ruby
+Protest.fail_fast = true
+```
+
+This feature can be configured by passing a `PROTEST_FAIL_FAST` environment
+variable, to activate it you must set it to `"true"`.
+
 ## Using Rails?
 
 If you are using Rails you may want to take a look at [protest-rails](http://github.com/matflores/protest-rails).

--- a/lib/protest.rb
+++ b/lib/protest.rb
@@ -106,7 +106,7 @@ require "protest/reports/summary"
 Protest.autorun = true
 Protest.report_with((ENV["PROTEST_REPORT"] || "documentation").to_sym)
 Protest.backtrace_filter = Protest::Utils::BacktraceFilter.new
-Protest.fail_fast = ENV["FAIL_FAST"] == "true"
+Protest.fail_fast = ENV["PROTEST_FAIL_FAST"] == "true"
 
 at_exit do
   exit $!.status if $!.is_a?(SystemExit) && !$!.success?

--- a/lib/protest.rb
+++ b/lib/protest.rb
@@ -32,14 +32,14 @@ module Protest
   end
 
   # Set to +true+ if tests should stop on the first failure. Default is +false+
-  def self.fail_fast=(flag)
-    @fail_fast = flag
+  def self.fail_early=(flag)
+    @fail_early = flag
   end
 
   # Checks to see if tests should stop on the first failure. Default is +false+
-  # See Protest.fail_fast=
-  def self.fail_fast?
-    !!@fail_fast
+  # See Protest.fail_early=
+  def self.fail_early?
+    !!@fail_early
   end
 
   # Run all registered test cases through the selected report. You can pass
@@ -106,7 +106,7 @@ require "protest/reports/summary"
 Protest.autorun = true
 Protest.report_with((ENV["PROTEST_REPORT"] || "documentation").to_sym)
 Protest.backtrace_filter = Protest::Utils::BacktraceFilter.new
-Protest.fail_fast = ENV["PROTEST_FAIL_FAST"] == "true"
+Protest.fail_early = ENV["PROTEST_FAIL_EARLY"] == "true"
 
 at_exit do
   exit $!.status if $!.is_a?(SystemExit) && !$!.success?

--- a/lib/protest.rb
+++ b/lib/protest.rb
@@ -106,6 +106,7 @@ require "protest/reports/summary"
 Protest.autorun = true
 Protest.report_with((ENV["PROTEST_REPORT"] || "documentation").to_sym)
 Protest.backtrace_filter = Protest::Utils::BacktraceFilter.new
+Protest.fail_fast = ENV["FAIL_FAST"] == "true"
 
 at_exit do
   exit $!.status if $!.is_a?(SystemExit) && !$!.success?

--- a/lib/protest.rb
+++ b/lib/protest.rb
@@ -31,6 +31,17 @@ module Protest
     !!@autorun
   end
 
+  # Set to +true+ if tests should stop on the first failure. Default is +false+
+  def self.fail_fast=(flag)
+    @fail_fast = flag
+  end
+
+  # Checks to see if tests should stop on the first failure. Default is +false+
+  # See Protest.fail_fast=
+  def self.fail_fast?
+    !!@fail_fast
+  end
+
   # Run all registered test cases through the selected report. You can pass
   # arguments to the Report constructor here.
   #

--- a/lib/protest/runner.rb
+++ b/lib/protest/runner.rb
@@ -43,7 +43,7 @@ module Protest
       event_handler_method = :"on_#{event}"
       @report.send(event_handler_method, *args) if @report.respond_to?(event_handler_method)
 
-      if Protest.fail_fast? && [:failure, :error].include?(event)
+      if Protest.fail_early? && [:failure, :error].include?(event)
         exit 1
       end
     end

--- a/lib/protest/runner.rb
+++ b/lib/protest/runner.rb
@@ -42,6 +42,10 @@ module Protest
     def fire_event(event, *args)
       event_handler_method = :"on_#{event}"
       @report.send(event_handler_method, *args) if @report.respond_to?(event_handler_method)
+
+      if Protest.fail_fast? && [:failure, :error].include?(event)
+        exit 1
+      end
     end
   end
 end

--- a/lib/protest/runner.rb
+++ b/lib/protest/runner.rb
@@ -32,9 +32,11 @@ module Protest
       fire_event :pending, PendingTest.new(test, e)
     rescue AssertionFailed => e
       fire_event :failure, FailedTest.new(test, e)
+      exit 1 if Protest.fail_early?
     rescue Exception => e
       raise if e.is_a?(Interrupt)
       fire_event :error, ErroredTest.new(test, e)
+      exit 1 if Protest.fail_early?
     end
 
     protected
@@ -42,10 +44,6 @@ module Protest
     def fire_event(event, *args)
       event_handler_method = :"on_#{event}"
       @report.send(event_handler_method, *args) if @report.respond_to?(event_handler_method)
-
-      if Protest.fail_early? && [:failure, :error].include?(event)
-        exit 1
-      end
     end
   end
 end


### PR DESCRIPTION
There are some scenarios when I would prefer that the test suite stops running when it stumbles upon an error.

For example: When I'm fixing a bunch of tests, and I think they are ready but they are not, in this cases it would be helpful that the suite stops running on the first error rather than needing me to stop the execution with `^C`.

This PR adds:
- `Protest.fail_early=` and `Protest.fail_early?` methods.
- The ability to stop the execution when `Protest.fail_early?` is true and a test case fails.
- The ability to set `Protest.fail_early=` using an environmental variable: `PROTEST_FAIL_EARLY=true`.