### PR TITLE
Improve failure summary printing.

### DIFF
--- a/lib/protest/utils/summaries.rb
+++ b/lib/protest/utils/summaries.rb
@@ -71,9 +71,11 @@ module Protest
         pad_indexes = failures_and_errors.size.to_s.size
         failures_and_errors.each_with_index do |error, index|
           colorize_as = ErroredTest === error ? :errored : :failed
-          puts "  #{pad(index+1, pad_indexes)}) #{test_type(error)}: `#{error.test_name}' (on line #{error.line} of `#{error.file}')", colorize_as
-          puts indent("With `#{error.error_message}'", 6 + pad_indexes), colorize_as
-          indent(error.backtrace, 6 + pad_indexes).each {|backtrace| puts backtrace, colorize_as }
+          lines = []
+          lines << "  #{pad(index+1, pad_indexes)}) #{test_type(error)}: `#{error.test_name}' (on line #{error.line} of `#{error.file}')"
+          lines.concat indent("With `#{error.error_message}'", 6 + pad_indexes)
+          lines.concat indent(error.backtrace, 6 + pad_indexes)
+          lines.each { |line| puts line, colorize_as }
           puts
         end
       end

--- a/lib/protest/utils/summaries.rb
+++ b/lib/protest/utils/summaries.rb
@@ -70,10 +70,17 @@ module Protest
 
         pad_indexes = failures_and_errors.size.to_s.size
         failures_and_errors.each_with_index do |error, index|
-          colorize_as = ErroredTest === error ? :errored : :failed
+          if ErroredTest === error
+            colorize_as = :errored
+            error_prefix = "With #{error.error.class.name}:"
+          else
+            colorize_as = :failed
+            error_prefix = "With"
+          end
+
           lines = []
           lines << "  #{pad(index+1, pad_indexes)}) #{test_type(error)}: `#{error.test_name}' (on line #{error.line} of `#{error.file}')"
-          lines.concat indent("With `#{error.error_message}'", 6 + pad_indexes)
+          lines.concat indent("#{error_prefix} `#{error.error_message}'", 6 + pad_indexes)
           lines.concat indent(error.backtrace, 6 + pad_indexes)
           lines.each { |line| puts line, colorize_as }
           puts


### PR DESCRIPTION
This PR makes two fixes/improvements to the printed output for failure summaries:

1. Fix the error message (second line of error summary) lines to be printed directly instead of printing an with "inspect" style, surrounded by array brackets and quotes (with contents escaped).  The array brackets and quotes were distracting, and the escaping of string contents made it harder to read embedded object representations.
2. Improve the error message lines by including the error class (only for tests that had an unhandled exception, not for tests that had an assertion failure).  The lack of printing the error class made it very frustrating to try to determine type of exception to rescue or otherwise deal with when the message was ambiguous.

Right now, failure summaries look like this (in `ruby 2.2.2p95`):
```
Failures:

  1) Error: `my test that errors' (on line 11 of `/home/jemc/1/code/gitx/protest/test/test_assertions.rb')
["       With `bad object {\"foo\"=>\"bar\"}'"]
       /home/jemc/1/code/gitx/protest/test/test_assertions.rb:11:in `block (2 levels) in <top (required)>'

  2) Failure: `my test that fails an assertion' (on line 14 of `/home/jemc/1/code/gitx/protest/test/test_assertions.rb')
["       With `\"foo\" expected but was \"bar\"'"]
       /home/jemc/1/code/gitx/protest/test/test_assertions.rb:14:in `block (2 levels) in <top (required)>'
```

After this PR, they look like this:
```
Failures:

  1) Error: `my test that errors' (on line 11 of `/home/jemc/1/code/gitx/protest/test/test_assertions.rb')
       With MyModule::MyError: `bad object {"foo"=>"bar"}'
       /home/jemc/1/code/gitx/protest/test/test_assertions.rb:11:in `block (2 levels) in <top (required)>'

  2) Failure: `my test that fails an assertion' (on line 14 of `/home/jemc/1/code/gitx/protest/test/test_assertions.rb')
       With `"foo" expected but was "bar"'
       /home/jemc/1/code/gitx/protest/test/test_assertions.rb:14:in `block (2 levels) in <top (required)>'
```