### PR TITLE
Add ability to filter tests on the command-line

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,16 @@ Protest.fail_early = true
 This feature can be configured by passing a `PROTEST_FAIL_EARLY` environment
 variable, to activate it you must set it to `"true"`.
 
+## Filtering
+
+You can filter the tests with an additional argument on the command-line,
+which will act as regex for test names:
+
+```ruby
+ruby -r test/something_test.rb --name 'something'
+ruby -r test/something_test.rb -n 'something'
+```
+
 ## Using Rails?
 
 If you are using Rails you may want to take a look at [protest-rails](http://github.com/matflores/protest-rails).

--- a/lib/protest/runner.rb
+++ b/lib/protest/runner.rb
@@ -1,3 +1,5 @@
+require "optparse"
+
 module Protest
   class Runner
     # Set up the test runner. Takes in a report that will be passed to test
@@ -10,10 +12,11 @@ module Protest
     # events on the runner's report, at the +start+ and +end+ of the test run,
     # and before and after each test case (+enter+ and +exit+.)
     def run(*test_cases)
+      options = parse_cli_options
       fire_event :start
       test_cases.each do |test_case|
         fire_event :enter, test_case
-        test_case.run(self)
+        test_case.run(self, options)
         fire_event :exit, test_case
       end
     rescue Interrupt
@@ -40,6 +43,15 @@ module Protest
     end
 
     protected
+
+    def parse_cli_options
+      options = {}
+      parser = OptionParser.new do |opts|
+        opts.on("-n", "--name NAME", String) { |name| options[:name] = name }
+      end
+      parser.parse!
+      options
+    end
 
     def fire_event(event, *args)
       event_handler_method = :"on_#{event}"

--- a/lib/protest/test_case.rb
+++ b/lib/protest/test_case.rb
@@ -31,8 +31,14 @@ module Protest
   class TestCase
     # Run all tests in this context. Takes a Runner instance in order to
     # provide output.
-    def self.run(runner)
-      tests.each {|test| runner.report(test) }
+    def self.run(runner, options = {})
+      tests_to_run = tests
+      if options[:name]
+        tests_to_run = tests.select do |test|
+          "#{test.class.description} #{test.name}" =~ Regexp.new(options[:name])
+        end
+      end
+      tests_to_run.each {|test| runner.report(test) }
     end
 
     # Tests added to this context.


### PR DESCRIPTION
Now we can run something like

```
$ ruby -r test/something_test.rb 'something'
```

and it will run all tests matching that regex.
