### PR TITLE
Add command-line interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,19 @@ Protest.fail_early = true
 This feature can be configured by passing a `PROTEST_FAIL_EARLY` environment
 variable, to activate it you must set it to `"true"`.
 
+### Command-Line
+
+Protest comes with a command-line interface for running tests:
+
+```
+$ protest --help
+Usage:
+  protest --help             # Show this help text
+  protest                    # Run all tests in test/**/*.rb
+  protest DIR                # Run all tests in DIR/**/*.rb
+  protest FILE1.rb FILE2.rb  # Run all tests in FILE1.rb and FILE2.rb
+```
+
 ## Using Rails?
 
 If you are using Rails you may want to take a look at [protest-rails](http://github.com/matflores/protest-rails).

--- a/bin/protest
+++ b/bin/protest
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+require "protest"
+
+usage = <<-TEXT
+Usage:
+  protest --help             # Show this help text
+  protest                    # Run all tests in test/**/*.rb
+  protest DIR                # Run all tests in DIR/**/*.rb
+  protest FILE1.rb FILE2.rb  # Run all tests in FILE1.rb and FILE2.rb
+TEXT
+
+test_files = case ARGV.first
+             when "-h", "--help" then warn usage; exit 0
+             when nil            then Dir["test/**/*.rb"]
+             else
+               ARGV.flat_map do |path|
+                 File.directory?(path) ? Dir["#{path}/**/*.rb"] : path
+               end
+             end
+
+test_files.each { |rb| require "./#{rb}" }

--- a/protest.gemspec
+++ b/protest.gemspec
@@ -13,5 +13,5 @@ Gem::Specification.new do |s|
   s.license       = "MIT"
   s.require_paths = ["lib"]
   s.files         = %w{ .gitignore CHANGELOG.md LICENSE README.md Rakefile protest.gemspec }
-  s.files        += Dir["lib/**/*.rb"]
+  s.files        += Dir["lib/**/*.rb", "bin/protest"]
 end

--- a/test/test_assertions.rb
+++ b/test/test_assertions.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative "test_helper"
 
 Protest.describe("Assertions") do
   describe "assert" do

--- a/test/test_report.rb
+++ b/test/test_report.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative "test_helper"
 
 module Protest
   class Reports::Test < Report

--- a/test/test_test_case.rb
+++ b/test/test_test_case.rb
@@ -1,4 +1,4 @@
-require "test_helper"
+require_relative "test_helper"
 
 Protest.describe("A test case") do
   it "records the number of assertions run" do


### PR DESCRIPTION
As a follow-up to https://github.com/matflores/protest/pull/8, this PR adds a `protest` command-line tool, which in addition to being a convenient way to require test files, can also be used for passing command-line arguments for future features.

In order to easily test the command-line tool I changed `require "tests_helper"` to `require_relative "test_helper"` in the test suite.