### PR TITLE
Add support for line numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,7 @@ Usage:
   protest                    # Run all tests in test/**/*.rb
   protest DIR                # Run all tests in DIR/**/*.rb
   protest FILE1.rb FILE2.rb  # Run all tests in FILE1.rb and FILE2.rb
+  protest FILE.rb:15         # Run tests in FILE.rb on line 15
 ```
 
 ## Using Rails?

--- a/bin/protest
+++ b/bin/protest
@@ -8,15 +8,35 @@ Usage:
   protest                    # Run all tests in test/**/*.rb
   protest DIR                # Run all tests in DIR/**/*.rb
   protest FILE1.rb FILE2.rb  # Run all tests in FILE1.rb and FILE2.rb
+  protest FILE.rb:15         # Run tests in FILE.rb on line 15
 TEXT
 
 test_files = case ARGV.first
              when "-h", "--help" then warn usage; exit 0
              when nil            then Dir["test/**/*.rb"]
              else
+               line_numbers = ARGV
+                 .select { |path| path[/:\d+$/] }
+                 .map { |path| path.split(":") }
+                 .map { |filename, line| [File.expand_path(filename), Integer(line)] }
+                 .to_h
+
                ARGV.flat_map do |path|
-                 File.directory?(path) ? Dir["#{path}/**/*.rb"] : path
+                 if File.directory?(path)
+                   Dir["#{path}/**/*.rb"]
+                 else
+                   path.sub(/:\d+$/, "")
+                 end
                end
              end
 
 test_files.each { |rb| require "./#{rb}" }
+
+options = {}
+options[:line_numbers] = line_numbers if line_numbers
+
+Protest.autorun = false
+Protest.run_all_tests!(options)
+
+report = Protest.instance_variable_get(:@report)
+exit report.failures_and_errors.empty?

--- a/lib/protest.rb
+++ b/lib/protest.rb
@@ -46,8 +46,8 @@ module Protest
   # arguments to the Report constructor here.
   #
   # See Protest.add_test_case and Protest.report_with
-  def self.run_all_tests!(*report_args)
-    Runner.new(@report).run(*test_cases)
+  def self.run_all_tests!(options = {})
+    Runner.new(@report).run(test_cases, options)
   end
 
   # Select the name of the Report to use when running tests. See

--- a/lib/protest/runner.rb
+++ b/lib/protest/runner.rb
@@ -9,11 +9,18 @@ module Protest
     # Run a set of test cases, provided as arguments. This will fire relevant
     # events on the runner's report, at the +start+ and +end+ of the test run,
     # and before and after each test case (+enter+ and +exit+.)
-    def run(*test_cases)
+    def run(test_cases, options = {})
       fire_event :start
-      test_cases.each do |test_case|
+
+      if options[:line_numbers]
+        test_groups = nearest_test_groups(test_cases, options[:line_numbers])
+      else
+        test_groups = test_cases.zip(test_cases.map(&:tests))
+      end
+
+      test_groups.each do |test_case, tests|
         fire_event :enter, test_case
-        test_case.run(self)
+        tests.each { |test| report(test) }
         fire_event :exit, test_case
       end
     rescue Interrupt
@@ -44,6 +51,37 @@ module Protest
     def fire_event(event, *args)
       event_handler_method = :"on_#{event}"
       @report.send(event_handler_method, *args) if @report.respond_to?(event_handler_method)
+    end
+
+    private
+
+    def nearest_test_groups(test_cases, line_numbers)
+      test_groups        = []
+      grouped_test_cases = test_cases.group_by(&:filename)
+
+      grouped_test_cases.each do |filename, test_cases|
+        if line_numbers.key?(filename)
+          line_number = line_numbers[filename]
+          runnables = test_cases + test_cases.flat_map(&:tests)
+          runnables.sort_by!(&:line_number).reverse!
+
+          runnable = runnables.find { |runnable| runnable.line_number <= line_number }
+          next if runnable.nil?
+
+          if runnable.is_a?(TestCase)
+            test_groups << [runnable.class, [runnable]]
+          elsif runnable < TestCase
+            test_groups << [runnable, runnable.tests]
+            test_cases.each do |test_case|
+              test_groups << [test_case, test_case.tests] if test_case < runnable
+            end
+          end
+        else
+          test_groups.concat test_cases.zip(test_cases.map(&:tests))
+        end
+      end
+
+      test_groups
     end
   end
 end


### PR DESCRIPTION
This pull requests extends the `protest` runner and Protest with the ability to specify line numbers:

```sh
$ protest test/test_something.rb:15 # runs tests on line 15
```

When a line number is specified, Protest will search for nearest test or test case upwards.

* If a line number is closest to a test, only that test is run our of all tests in that file
* If a line number is closest to a test case, it will run all tests in that test case and its descendants
* If no tests or test cases are found above the specified line number, no tests from that file are run

Closes https://github.com/matflores/protest/issues/10