### PR TITLE
Correctly register the CLI in gemspec

### DIFF
--- a/protest.gemspec
+++ b/protest.gemspec
@@ -13,5 +13,6 @@ Gem::Specification.new do |s|
   s.license       = "MIT"
   s.require_paths = ["lib"]
   s.files         = %w{ .gitignore CHANGELOG.md LICENSE README.md Rakefile protest.gemspec }
-  s.files        += Dir["lib/**/*.rb", "bin/protest"]
+  s.files        += Dir["lib/**/*.rb"]
+  s.executable    = "protest"
 end


### PR DESCRIPTION
Currently the `protest` executable doesn't become available in the `$PATH`, so this fixes it.